### PR TITLE
Fix typo in custom command shortcut example

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ keybindings.json:
     //Execute Lazygit command defined in binocular.command.commands settings.
     {
         "key": "alt+g",
-        "command": "binocular.executeCommand",
+        "command": "binocular.customCommands",
         "args": "Lazygit"
     },
 ```


### PR DESCRIPTION
I tried the custom command shortcut example in the README.md but it seems like there's no command named "binocular.executeCommand". It's called "binocular.customCommands".